### PR TITLE
(maint) Fix build for UI and bot

### DIFF
--- a/.github/workflows/build-and-publish-bot.yaml
+++ b/.github/workflows/build-and-publish-bot.yaml
@@ -36,7 +36,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
-          context: services/bot
+          context: .
+          file: services/bot/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-publish-ui.yaml
+++ b/.github/workflows/build-and-publish-ui.yaml
@@ -37,7 +37,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
-          context: services/ui
+          context: .
+          file: services/ui/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Now that the UI and bot depend on a shared package for the API types, the context for the images needs to be the root of the repo. Updated the build actions for both to reflect this change.