### PR TITLE
(maint) Upgrade `generate-environment` package

### DIFF
--- a/services/backend/package-lock.json
+++ b/services/backend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "discord-movie-list-backend",
       "version": "0.1.0",
       "dependencies": {
-        "@mardotio/generate-environment": "^0.2.0",
+        "@mardotio/generate-environment": "^1.0.1",
         "bcrypt": "^5.0.1",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/@mardotio/generate-environment": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mardotio/generate-environment/-/generate-environment-0.2.0.tgz",
-      "integrity": "sha512-OrDQ3LOnSJ3VzFXn4ttcQV3EojXeIPLqXu6ZFuMQiLE879s1b6ez8IbLSGsU8ZajfYI62+VsAp2KGFln0oCwsw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mardotio/generate-environment/-/generate-environment-1.0.1.tgz",
+      "integrity": "sha512-qnw5RrJSrd04yCqLF5PbvCFV2VP6Uss+g9gML59Gre0upwOA62lb37BCbsjM6hLlOg+tNvSt/9XiLb4i8KGCeA=="
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -7010,9 +7010,9 @@
       }
     },
     "@mardotio/generate-environment": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mardotio/generate-environment/-/generate-environment-0.2.0.tgz",
-      "integrity": "sha512-OrDQ3LOnSJ3VzFXn4ttcQV3EojXeIPLqXu6ZFuMQiLE879s1b6ez8IbLSGsU8ZajfYI62+VsAp2KGFln0oCwsw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mardotio/generate-environment/-/generate-environment-1.0.1.tgz",
+      "integrity": "sha512-qnw5RrJSrd04yCqLF5PbvCFV2VP6Uss+g9gML59Gre0upwOA62lb37BCbsjM6hLlOg+tNvSt/9XiLb4i8KGCeA=="
     },
     "@sideway/address": {
       "version": "4.1.4",

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -15,7 +15,7 @@
     "format": "./node_modules/prettier/bin-prettier.js --loglevel silent --write ."
   },
   "dependencies": {
-    "@mardotio/generate-environment": "^0.2.0",
+    "@mardotio/generate-environment": "^1.0.1",
     "bcrypt": "^5.0.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/services/backend/src/util/environment.ts
+++ b/services/backend/src/util/environment.ts
@@ -1,42 +1,31 @@
 import generateEnvironment from '@mardotio/generate-environment';
 
-type EnvironmentVariables =
-  | 'POSTGRES_DB'
-  | 'POSTGRES_USER'
-  | 'POSTGRES_PASSWORD'
-  | 'POSTGRES_PORT'
-  | 'POSTGRES_HOST'
-  | 'SERVER_PORT'
-  | 'APP_HOST'
-  | 'DISCORD_HOOK'
-  | 'JWT_SECRET'
-  | 'DISCORD_BOT_JWT_SECRET'
-  | 'DISCORD_JWT_SECRET';
+const validateEnv = () => {
+  const result = generateEnvironment({
+    required: [
+      'POSTGRES_DB',
+      'POSTGRES_USER',
+      'POSTGRES_PASSWORD',
+      'POSTGRES_PORT',
+      'POSTGRES_HOST',
+      'SERVER_PORT',
+      'DISCORD_JWT_SECRET',
+      'JWT_SECRET',
+      'DISCORD_BOT_JWT_SECRET',
+      // 'APP_HOST',
+      // 'DISCORD_HOOK',
+    ] as const,
+    optional: ['ENVIRONMENT_MODE'] as const,
+  });
 
-type OptionalEnvironmentVariables = 'ENVIRONMENT_MODE';
+  if (result.errors !== null) {
+     throw new Error(`The following environment variables were not set:\n${result.errors.join('\n')}`);
+  }
 
-const ENVIRONMENT_VARIABLES: EnvironmentVariables[] = [
-  'POSTGRES_DB',
-  'POSTGRES_USER',
-  'POSTGRES_PASSWORD',
-  'POSTGRES_PORT',
-  'POSTGRES_HOST',
-  'SERVER_PORT',
-  'DISCORD_JWT_SECRET',
-  'JWT_SECRET',
-  'DISCORD_BOT_JWT_SECRET',
-  // 'APP_HOST',
-  // 'DISCORD_HOOK',
-];
+  return result.environment;
+};
 
-const OPTIONAL_ENVIRONMENT_VARIABLES: OptionalEnvironmentVariables[] = [
-  'ENVIRONMENT_MODE',
-];
-
-const APP_ENVIRONMENT = generateEnvironment(
-  ENVIRONMENT_VARIABLES,
-  OPTIONAL_ENVIRONMENT_VARIABLES,
-);
+const APP_ENVIRONMENT = validateEnv();
 
 export const isProduction =
   !APP_ENVIRONMENT.ENVIRONMENT_MODE ||

--- a/services/bot/package-lock.json
+++ b/services/bot/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@mardotio/generate-environment": "^0.2.0",
+        "@mardotio/generate-environment": "^1.0.1",
         "date-fns": "^2.21.3",
         "discord-api-types": "^0.37.7",
         "discord.js": "^14.3.0",
@@ -292,9 +292,9 @@
       "link": true
     },
     "node_modules/@mardotio/generate-environment": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mardotio/generate-environment/-/generate-environment-0.2.0.tgz",
-      "integrity": "sha512-OrDQ3LOnSJ3VzFXn4ttcQV3EojXeIPLqXu6ZFuMQiLE879s1b6ez8IbLSGsU8ZajfYI62+VsAp2KGFln0oCwsw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mardotio/generate-environment/-/generate-environment-1.0.1.tgz",
+      "integrity": "sha512-qnw5RrJSrd04yCqLF5PbvCFV2VP6Uss+g9gML59Gre0upwOA62lb37BCbsjM6hLlOg+tNvSt/9XiLb4i8KGCeA=="
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.0",
@@ -5688,9 +5688,9 @@
       "version": "file:../../packages/api-types"
     },
     "@mardotio/generate-environment": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mardotio/generate-environment/-/generate-environment-0.2.0.tgz",
-      "integrity": "sha512-OrDQ3LOnSJ3VzFXn4ttcQV3EojXeIPLqXu6ZFuMQiLE879s1b6ez8IbLSGsU8ZajfYI62+VsAp2KGFln0oCwsw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mardotio/generate-environment/-/generate-environment-1.0.1.tgz",
+      "integrity": "sha512-qnw5RrJSrd04yCqLF5PbvCFV2VP6Uss+g9gML59Gre0upwOA62lb37BCbsjM6hLlOg+tNvSt/9XiLb4i8KGCeA=="
     },
     "@sapphire/async-queue": {
       "version": "1.5.0",

--- a/services/bot/package.json
+++ b/services/bot/package.json
@@ -16,7 +16,7 @@
     "preinstall": "cd ../../packages/api-types && npm run generate"
   },
   "dependencies": {
-    "@mardotio/generate-environment": "^0.2.0",
+    "@mardotio/generate-environment": "^1.0.1",
     "date-fns": "^2.21.3",
     "discord-api-types": "^0.37.7",
     "discord.js": "^14.3.0",

--- a/services/bot/src/utils/environment.ts
+++ b/services/bot/src/utils/environment.ts
@@ -1,28 +1,25 @@
 import generateEnvironment from '@mardotio/generate-environment';
 
-type BotRequiredEnvVars =
-  | 'DISCORD_BOT_TOKEN'
-  | 'DISCORD_JWT_SECRET'
-  | 'DISCORD_BOT_JWT_SECRET'
-  | 'UI_ENDPOINT'
-  | 'DISCORD_BOT_ID';
+const validateEnv = () => {
+  const result = generateEnvironment({
+    required: [
+      'DISCORD_BOT_TOKEN',
+      'DISCORD_JWT_SECRET',
+      'DISCORD_BOT_JWT_SECRET',
+      'UI_ENDPOINT',
+      'DISCORD_BOT_ID',
+    ] as const,
+    optional: ['ENVIRONMENT_MODE'] as const,
+  });
 
-type BotOptionalEnvVars = 'ENVIRONMENT_MODE';
+  if (result.errors !== null) {
+     throw new Error(`The following environment variables were not set:\n${result.errors.join('\n')}`);
+  }
 
-const BOT_REQUIRED_ENV_VARS: BotRequiredEnvVars[] = [
-  'DISCORD_BOT_TOKEN',
-  'DISCORD_JWT_SECRET',
-  'DISCORD_BOT_JWT_SECRET',
-  'UI_ENDPOINT',
-  'DISCORD_BOT_ID',
-];
+  return result.environment;
+};
 
-const BOT_OPTIONAL_ENV_VARS: BotOptionalEnvVars[] = ['ENVIRONMENT_MODE'];
-
-export const BOT_ENVIRONMENT = generateEnvironment(
-  BOT_REQUIRED_ENV_VARS,
-  BOT_OPTIONAL_ENV_VARS,
-);
+export const BOT_ENVIRONMENT = validateEnv();
 
 export const isProduction =
   !BOT_ENVIRONMENT.ENVIRONMENT_MODE ||


### PR DESCRIPTION
Upgraded the `generate-environment` package in order to use named parameters. Also removed redundant environment variables type in favor of the `as const` pattern.